### PR TITLE
[FEAT] 팀 생성, 조회 UI 구현

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,17 +1,57 @@
-import React from "react";
-import { Leaf, PlusCircle, User, Users } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { Leaf, PlusCircle, User, Users, X } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import api from "../../services/api.js";
 
 const Sidebar = () => {
   const navigate = useNavigate();
+  const [teams, setTeams] = useState([]);
+  const [newTeamName, setNewTeamName] = useState("");
+  const [isCreatingTeam, setIsCreatingTeam] = useState(false);
+
+  useEffect(() => {
+    fetchTeams();
+  }, []);
+
+  const fetchTeams = async () => {
+    try {
+      const response = await api.get("/teams");
+      if (response.status === 200) setTeams(response.data);
+    } catch (error) {
+      console.error("팀 목록을 불러오는데 실패했습니다.", error);
+    }
+  };
+
+  const createNewTeam = async (e) => {
+    e.preventDefault();
+    if (!newTeamName.trim()) return;
+    try {
+      const response = await api.post("/teams", { teamName: newTeamName });
+      if (response.status === 200) {
+        setNewTeamName("");
+        setIsCreatingTeam(false);
+        fetchTeams();
+      }
+    } catch (error) {
+      console.error("새 팀 생성에 실패했습니다.", error);
+      if (error.response && error.response.status === 409) {
+        alert(error.response.data.message);
+      }
+    }
+  };
+
+  const toggleCreateTeam = () => {
+    setIsCreatingTeam(!isCreatingTeam);
+    if (isCreatingTeam) {
+      setNewTeamName("");
+    }
+  };
 
   return (
       <div className="w-64 bg-white p-4 border-r border-gray-200 h-screen fixed">
-        <div className="flex items-center mb-20 ml-2">
+        <div className="flex items-center mb-20 ml-2 cursor-pointer" onClick={() => navigate('/')}>
           <Leaf className="h-12 w-12 text-green-600"/>
-          <span className="ml-2 text-3xl font-semibold cursor-pointer" onClick={() => navigate('/')}>
-          DoToli
-        </span>
+          <span className="ml-2 text-3xl font-semibold">DoToli</span>
         </div>
         <nav className="space-y-6 ml-3">
           <div>
@@ -19,9 +59,9 @@ const Sidebar = () => {
               <User className="h-4 w-4 mr-2"/>
               개인 작업 공간
             </h3>
-            <a href="#" className="flex items-center hover:bg-blue-50 rounded-md p-2">
+            <Link to="/" className="flex items-center hover:bg-blue-50 rounded-md p-2">
               <span className="mr-3">My Todo</span>
-            </a>
+            </Link>
           </div>
           <div>
             <h3 className="text-sm font-medium text-gray-500 mb-2 flex items-center justify-between">
@@ -29,21 +69,48 @@ const Sidebar = () => {
               <Users className="h-4 w-4 mr-2"/>
               팀 작업 공간
             </span>
-              <PlusCircle className="cursor-pointer"/>
+              <button
+                  className="w-6 h-6 flex items-center justify-center rounded-full bg-gray-200 hover:bg-gray-300 transition-all duration-300 ease-in-out transform hover:scale-110"
+                  onClick={toggleCreateTeam}
+              >
+                {isCreatingTeam ? (
+                    <X className="h-4 w-4 text-gray-600 transition-transform duration-300 ease-in-out transform rotate-0 hover:rotate-90"/>
+                ) : (
+                    <PlusCircle
+                        className="h-4 w-4 text-gray-600 transition-transform duration-300 ease-in-out transform rotate-0 hover:rotate-90"/>
+                )}
+              </button>
             </h3>
+            <div
+                className={`overflow-hidden transition-all duration-300 ease-in-out ${isCreatingTeam ? 'max-h-32' : 'max-h-0'}`}>
+              <form onSubmit={createNewTeam} className="mb-2">
+                <input
+                    type="text"
+                    value={newTeamName}
+                    onChange={(e) => setNewTeamName(e.target.value)}
+                    placeholder="새 팀 이름"
+                    className="w-full p-2 border rounded"
+                />
+                <button type="submit"
+                        className="mt-2 w-full bg-blue-500 text-white p-2 rounded hover:bg-blue-600 transition-colors duration-300">
+                  팀 생성
+                </button>
+              </form>
+            </div>
             <ul className="space-y-2">
-              {['My Team', 'My Team', 'My Team'].map((team, index) => (
-                  <li key={index}>
-                    <a href="#" className="flex items-center text-gray-700 hover:bg-gray-100 rounded-md p-2">
-                      {team}
-                    </a>
+              {teams.map((team) => (
+                  <li key={team.id}>
+                    <Link to={`/team/${team.id}`}
+                          className="flex items-center text-gray-700 hover:bg-gray-100 rounded-md p-2 transition-colors duration-300">
+                      {team.teamName}
+                    </Link>
                   </li>
               ))}
             </ul>
           </div>
         </nav>
       </div>
-  )
-}
+  );
+};
 
 export default Sidebar;

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,15 +1,49 @@
-import { Menu } from "lucide-react";
+import React from "react";
+import { Leaf, PlusCircle, User, Users } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
-const Sidebar = () => (
-    <div className="w-64 bg-gray-100 p-4 border-r border-gray-200 h-screen fixed">
-      <div className="flex items-center mb-4">
-        <Menu className="w-5 h-5 mr-2"/>
-        <h1 className="text-lg font-semibold">Workspace</h1>
+const Sidebar = () => {
+  const navigate = useNavigate();
+
+  return (
+      <div className="w-64 bg-white p-4 border-r border-gray-200 h-screen fixed">
+        <div className="flex items-center mb-20 ml-2">
+          <Leaf className="h-12 w-12 text-green-600"/>
+          <span className="ml-2 text-3xl font-semibold cursor-pointer" onClick={() => navigate('/')}>
+          DoToli
+        </span>
+        </div>
+        <nav className="space-y-6 ml-3">
+          <div>
+            <h3 className="text-sm font-medium text-gray-500 mb-2 flex items-center">
+              <User className="h-4 w-4 mr-2"/>
+              개인 작업 공간
+            </h3>
+            <a href="#" className="flex items-center hover:bg-blue-50 rounded-md p-2">
+              <span className="mr-3">My Todo</span>
+            </a>
+          </div>
+          <div>
+            <h3 className="text-sm font-medium text-gray-500 mb-2 flex items-center justify-between">
+            <span className="flex items-center">
+              <Users className="h-4 w-4 mr-2"/>
+              팀 작업 공간
+            </span>
+              <PlusCircle className="cursor-pointer"/>
+            </h3>
+            <ul className="space-y-2">
+              {['My Team', 'My Team', 'My Team'].map((team, index) => (
+                  <li key={index}>
+                    <a href="#" className="flex items-center text-gray-700 hover:bg-gray-100 rounded-md p-2">
+                      {team}
+                    </a>
+                  </li>
+              ))}
+            </ul>
+          </div>
+        </nav>
       </div>
-      <nav>
-        {/* Navigation links */}
-      </nav>
-    </div>
-);
+  )
+}
 
 export default Sidebar;


### PR DESCRIPTION
## 관련 이슈
- Closes #6 

## 변경 사항
1. 사이드바 컴포넌트 구현
   - 임시 로고 및 앱 이름 추가
   - 개인 작업 공간 섹션 구현
   - 팀 작업 공간 섹션 구현
2. 팀 관리 기능 추가
   - 팀 목록 조회 및 표시
   - 새 팀 생성 기능 구현
3. UI/UX 개선
   - 애니메이션 효과 추가 (팀 생성 폼 토글, 버튼 호버 효과 등)
4. API 연동
   - 팀 목록 조회 API 연동
   - 팀 생성 API 연동

## 스크린샷
`사이드바 UI 개선`
|변경 전|변경 후 |
|---|---|
|![변경 전 사이드바](https://github.com/user-attachments/assets/8a93b27c-92bf-4f4c-9e86-cdd910a6bf2c)|![변경 후 사이드바](https://github.com/user-attachments/assets/8a2262e2-5619-4c91-8227-699fcb3b3f7e)|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- 사이드바 컴포넌트는 `Sidebar.jsx`에 구현되어 있으며, 재사용 가능한 구조로 설계하였습니다.

## 추후 업무
- [ ] 팀 할 일 목록 페이지 구현
- [ ] 팀 멤버 관리 기능 추가 (초대, 역할 변경 등)