### PR TITLE
[FEAT] 팀 할 일 목록 페이지 초안 구현 및 검색 입력창 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import SigninPage from "./pages/SigninPage.jsx";
 import PersonalTaskListPage from "./pages/PersonalTaskListPage.jsx";
 import PrivateRoute from "./components/PrivateRoute.jsx";
 import Mypage from "./pages/MyPage.jsx";
+import TeamTaskListPage from "./pages/TeamTaskListPage.jsx";
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
             <Route path="/signin" element={<SigninPage/>}/>
             <Route element={<PrivateRoute/>}>
               <Route path="/" element={<PersonalTaskListPage/>}/>
+              <Route path="/team/:teamId" element={<TeamTaskListPage/>}/>
               <Route path="/mypage" element={<Mypage/>}/>
             </Route>
             <Route path="*" element={<NotFound/>}/>

--- a/src/components/TaskListPage.jsx
+++ b/src/components/TaskListPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import TaskList from '../components/TaskList';
+import { Search } from 'lucide-react'; // lucide-react 아이콘 사용
 
 const TaskListPage = ({
                         title,
@@ -12,7 +13,19 @@ const TaskListPage = ({
                         handleTaskEdit
                       }) => {
   return (
-      <div className="flex flex-col items-center justify-start min-h-screen p-8">
+      <div className="flex flex-col items-center justify-start min-h-screen">
+        {/* Search Bar Placeholder */}
+        <div className="w-full max-w-2xl mb-4">
+          <div className="relative">
+            <input
+                type="text"
+                placeholder="Search Task"
+                className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"/>
+          </div>
+        </div>
+
         <div className="w-full max-w-2xl bg-white rounded-lg shadow-md p-6">
           <h2 className="text-3xl font-bold text-gray-800 mb-6">{title}</h2>
           <form onSubmit={handleAddTask} className="mb-6">

--- a/src/components/TaskListPage.jsx
+++ b/src/components/TaskListPage.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import TaskList from '../components/TaskList';
+
+const TaskListPage = ({
+                        title,
+                        tasks,
+                        content,
+                        handleContentChange,
+                        handleAddTask,
+                        handleTaskToggle,
+                        handleTaskDelete,
+                        handleTaskEdit
+                      }) => {
+  return (
+      <div className="flex flex-col items-center justify-start min-h-screen p-8">
+        <div className="w-full max-w-2xl bg-white rounded-lg shadow-md p-6">
+          <h2 className="text-3xl font-bold text-gray-800 mb-6">{title}</h2>
+          <form onSubmit={handleAddTask} className="mb-6">
+            <div className="flex items-center">
+              <input
+                  type="text"
+                  id="content"
+                  name="content"
+                  value={content}
+                  onChange={handleContentChange}
+                  required
+                  className="flex-grow mr-2 p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="새로운 할 일을 입력하세요"
+              />
+              <button
+                  type="submit"
+                  className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                추가
+              </button>
+            </div>
+          </form>
+          <TaskList
+              tasks={tasks}
+              onTaskToggle={handleTaskToggle}
+              onTaskDelete={handleTaskDelete}
+              onTaskEdit={handleTaskEdit}
+          />
+        </div>
+      </div>
+  );
+};
+
+export default TaskListPage;

--- a/src/hooks/useTaskList.js
+++ b/src/hooks/useTaskList.js
@@ -72,7 +72,8 @@ const useTaskList = (baseUrl) => {
     handleAddTask,
     handleTaskDelete,
     handleTaskEdit,
-    handleTaskToggle
+    handleTaskToggle,
+    fetchTasks
   };
 };
 

--- a/src/hooks/useTaskList.js
+++ b/src/hooks/useTaskList.js
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useState } from 'react';
+import api from "../services/api.js";
+
+const useTaskList = (baseUrl) => {
+  const [tasks, setTasks] = useState([]);
+  const [content, setContent] = useState('');
+
+  const fetchTasks = useCallback(async () => {
+    try {
+      const response = await api.get(baseUrl);
+      setTasks(response.data);
+    } catch (err) {
+      console.error(err);
+      alert('할 일 목록을 불러오는데 실패했습니다.');
+    }
+  }, [baseUrl]);
+
+  useEffect(() => {
+    fetchTasks();
+  }, [fetchTasks]);
+
+  const handleContentChange = (e) => {
+    setContent(e.target.value);
+  };
+
+  const handleAddTask = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post(baseUrl, { content });
+      setContent('');
+      fetchTasks();
+    } catch (err) {
+      console.error(err);
+      alert('할 일 추가에 실패했습니다.');
+    }
+  };
+
+  const handleTaskDelete = async (taskId) => {
+    try {
+      await api.delete(`${baseUrl}/${taskId}`);
+      fetchTasks();
+    } catch (err) {
+      console.error(err);
+      alert('할 일 삭제에 실패했습니다.');
+    }
+  };
+
+  const handleTaskEdit = async (taskId, newContent) => {
+    try {
+      await api.put(`${baseUrl}/${taskId}`, { content: newContent });
+      fetchTasks();
+    } catch (err) {
+      console.error(err);
+      alert('할 일 수정에 실패했습니다.');
+    }
+  };
+
+  const handleTaskToggle = async (taskId) => {
+    try {
+      await api.put(`${baseUrl}/${taskId}/toggle`, { done: !tasks.find(task => task.id === taskId).done });
+      fetchTasks();
+    } catch (err) {
+      console.error(err);
+      alert('할 일 상태 변경에 실패했습니다.');
+    }
+  };
+
+  return {
+    tasks,
+    content,
+    handleContentChange,
+    handleAddTask,
+    handleTaskDelete,
+    handleTaskEdit,
+    handleTaskToggle
+  };
+};
+
+export default useTaskList;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,7 @@
 import './index.css'
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
-    <StrictMode>
-      <App/>
-    </StrictMode>,
+    <App/>
 )

--- a/src/pages/PersonalTaskListPage.jsx
+++ b/src/pages/PersonalTaskListPage.jsx
@@ -1,103 +1,29 @@
-import React, { useEffect, useState } from 'react';
-import TaskList from '../components/TaskList';
-import api from "../services/api.js";
+import React from 'react';
+import useTaskList from '../hooks/useTaskList';
+import TaskListPage from '../components/TaskListPage';
 
 const PersonalTaskListPage = () => {
-  const [tasks, setTasks] = useState([]);
-  const [content, setContent] = useState('');
-
-  useEffect(() => {
-    fetchTasks();
-  }, []);
-
-  const fetchTasks = async () => {
-    try {
-      const response = await api.get('/tasks');
-      setTasks(response.data);
-    } catch (err) {
-      console.error(err);
-      alert('할 일 목록을 불러오는데 실패했습니다.');
-    }
-  };
-
-  const handleContentChange = (e) => {
-    setContent(e.target.value);
-  };
-
-  const handleAddTask = async (e) => {
-    e.preventDefault();
-    try {
-      await api.post('/tasks', { content });
-      setContent('');
-      fetchTasks();
-    } catch (err) {
-      console.error(err);
-      alert('할 일 추가에 실패했습니다.');
-    }
-  };
-
-  const handleTaskDelete = async (taskId) => {
-    try {
-      await api.delete(`/tasks/${taskId}`);
-      fetchTasks();  // 삭제 후 목록 새로고침
-    } catch (err) {
-      console.error(err);
-      alert('할 일 삭제에 실패했습니다.');
-    }
-  };
-
-  const handleTaskEdit = async (taskId, newContent) => {
-    try {
-      await api.put(`/tasks/${taskId}`, { content: newContent });
-      fetchTasks();  // 수정 후 목록 새로고침
-    } catch (err) {
-      console.error(err);
-      alert('할 일 수정에 실패했습니다.');
-    }
-  };
-
-  const handleTaskToggle = async (taskId) => {
-    try {
-      await api.put(`/tasks/${taskId}/toggle`, { done: !tasks.find(task => task.id === taskId).done });
-      fetchTasks();
-    } catch (err) {
-      console.error(err);
-      alert('할 일 상태 변경에 실패했습니다.');
-    }
-  };
+  const {
+    tasks,
+    content,
+    handleContentChange,
+    handleAddTask,
+    handleTaskDelete,
+    handleTaskEdit,
+    handleTaskToggle
+  } = useTaskList('/tasks');
 
   return (
-      <div className="flex flex-col items-center justify-start min-h-screen p-8">
-        <div className="w-full max-w-2xl bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-3xl font-bold text-gray-800 mb-6">개인 할 일 목록</h2>
-          <form onSubmit={handleAddTask} className="mb-6">
-            <div className="flex items-center">
-              <input
-                  type="text"
-                  id="content"
-                  name="content"
-                  value={content}
-                  onChange={handleContentChange}
-                  required
-                  className="flex-grow mr-2 p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="새로운 할 일을 입력하세요"
-              />
-              <button
-                  type="submit"
-                  className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                추가
-              </button>
-            </div>
-          </form>
-          <TaskList
-              tasks={tasks}
-              onTaskToggle={handleTaskToggle}
-              onTaskDelete={handleTaskDelete}
-              onTaskEdit={handleTaskEdit}
-          />
-        </div>
-      </div>
+      <TaskListPage
+          title="개인 할 일 목록"
+          tasks={tasks}
+          content={content}
+          handleContentChange={handleContentChange}
+          handleAddTask={handleAddTask}
+          handleTaskToggle={handleTaskToggle}
+          handleTaskDelete={handleTaskDelete}
+          handleTaskEdit={handleTaskEdit}
+      />
   );
 };
 

--- a/src/pages/TeamTaskListPage.jsx
+++ b/src/pages/TeamTaskListPage.jsx
@@ -1,106 +1,46 @@
 import React, { useEffect, useState } from 'react';
-import TaskList from '../components/TaskList';
-import api from "../services/api.js";
 import { useParams } from "react-router-dom";
+import useTaskList from '../hooks/useTaskList';
+import TaskListPage from '../components/TaskListPage';
+import api from "../services/api.js";
 
 const TeamTaskListPage = () => {
   const { teamId } = useParams();
-  const [tasks, setTasks] = useState([]);
-  const [content, setContent] = useState('');
+  const [teamName, setTeamName] = useState('');
+  const {
+    tasks,
+    content,
+    handleContentChange,
+    handleAddTask,
+    handleTaskDelete,
+    handleTaskEdit,
+    handleTaskToggle
+  } = useTaskList(`/team/${teamId}/tasks`);
 
   useEffect(() => {
-    fetchTasks();
-  }, []);
-
-  const fetchTasks = async () => {
-    try {
-      const response = await api.get(`/team/${teamId}/tasks`);
-      setTasks(response.data);
-    } catch (err) {
-      console.error(err);
-      alert('할 일 목록을 불러오는데 실패했습니다.');
-    }
-  };
-
-  const handleContentChange = (e) => {
-    setContent(e.target.value);
-  };
-
-  const handleAddTask = async (e) => {
-    e.preventDefault();
-    try {
-      await api.post(`/team/${teamId}/tasks`, { content });
-      setContent('');
-      fetchTasks();
-    } catch (err) {
-      console.error(err);
-      alert('할 일 추가에 실패했습니다.');
-    }
-  };
-
-  const handleTaskDelete = async (taskId) => {
-    try {
-      await api.delete(`/team/${teamId}/tasks/${taskId}`);
-      fetchTasks();  // 삭제 후 목록 새로고침
-    } catch (err) {
-      console.error(err);
-      alert('할 일 삭제에 실패했습니다.');
-    }
-  };
-
-  const handleTaskEdit = async (taskId, newContent) => {
-    try {
-      await api.put(`/team/${teamId}/tasks/${taskId}`, { content: newContent });
-      fetchTasks();  // 수정 후 목록 새로고침
-    } catch (err) {
-      console.error(err);
-      alert('할 일 수정에 실패했습니다.');
-    }
-  };
-
-  const handleTaskToggle = async (taskId) => {
-    try {
-      await api.put(`/team/${teamId}/tasks/${taskId}/toggle`, { done: !tasks.find(task => task.id === taskId).done });
-      fetchTasks();
-    } catch (err) {
-      console.error(err);
-      alert('할 일 상태 변경에 실패했습니다.');
-    }
-  };
+    const fetchTeamName = async () => {
+      try {
+        const response = await api.get(`/team/${teamId}`);
+        setTeamName(response.data.name);
+      } catch (err) {
+        console.error(err);
+        alert('팀 정보를 불러오는데 실패했습니다.');
+      }
+    };
+    fetchTeamName();
+  }, [teamId]);
 
   return (
-      <div className="flex flex-col items-center justify-start min-h-screen p-8">
-        <div className="w-full max-w-2xl bg-white rounded-lg shadow-md p-6">
-          {/* TODO 팀 이름 조회 필요 */}
-          <h2 className="text-3xl font-bold text-gray-800 mb-6">팀 이름 할 일 목록</h2>
-          <form onSubmit={handleAddTask} className="mb-6">
-            <div className="flex items-center">
-              <input
-                  type="text"
-                  id="content"
-                  name="content"
-                  value={content}
-                  onChange={handleContentChange}
-                  required
-                  className="flex-grow mr-2 p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="새로운 할 일을 입력하세요"
-              />
-              <button
-                  type="submit"
-                  className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                추가
-              </button>
-            </div>
-          </form>
-          <TaskList
-              tasks={tasks}
-              onTaskToggle={handleTaskToggle}
-              onTaskDelete={handleTaskDelete}
-              onTaskEdit={handleTaskEdit}
-          />
-        </div>
-      </div>
+      <TaskListPage
+          title={`${teamName} 할 일 목록`}
+          tasks={tasks}
+          content={content}
+          handleContentChange={handleContentChange}
+          handleAddTask={handleAddTask}
+          handleTaskToggle={handleTaskToggle}
+          handleTaskDelete={handleTaskDelete}
+          handleTaskEdit={handleTaskEdit}
+      />
   );
 };
 

--- a/src/pages/TeamTaskListPage.jsx
+++ b/src/pages/TeamTaskListPage.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import TaskList from '../components/TaskList';
+import api from "../services/api.js";
+import { useParams } from "react-router-dom";
+
+const TeamTaskListPage = () => {
+  const { teamId } = useParams();
+  const [tasks, setTasks] = useState([]);
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    fetchTasks();
+  }, []);
+
+  const fetchTasks = async () => {
+    try {
+      const response = await api.get(`/team/${teamId}/tasks`);
+      setTasks(response.data);
+    } catch (err) {
+      console.error(err);
+      alert('할 일 목록을 불러오는데 실패했습니다.');
+    }
+  };
+
+  const handleContentChange = (e) => {
+    setContent(e.target.value);
+  };
+
+  const handleAddTask = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post(`/team/${teamId}/tasks`, { content });
+      setContent('');
+      fetchTasks();
+    } catch (err) {
+      console.error(err);
+      alert('할 일 추가에 실패했습니다.');
+    }
+  };
+
+  const handleTaskDelete = async (taskId) => {
+    try {
+      await api.delete(`/team/${teamId}/tasks/${taskId}`);
+      fetchTasks();  // 삭제 후 목록 새로고침
+    } catch (err) {
+      console.error(err);
+      alert('할 일 삭제에 실패했습니다.');
+    }
+  };
+
+  const handleTaskEdit = async (taskId, newContent) => {
+    try {
+      await api.put(`/team/${teamId}/tasks/${taskId}`, { content: newContent });
+      fetchTasks();  // 수정 후 목록 새로고침
+    } catch (err) {
+      console.error(err);
+      alert('할 일 수정에 실패했습니다.');
+    }
+  };
+
+  const handleTaskToggle = async (taskId) => {
+    try {
+      await api.put(`/team/${teamId}/tasks/${taskId}/toggle`, { done: !tasks.find(task => task.id === taskId).done });
+      fetchTasks();
+    } catch (err) {
+      console.error(err);
+      alert('할 일 상태 변경에 실패했습니다.');
+    }
+  };
+
+  return (
+      <div className="flex flex-col items-center justify-start min-h-screen p-8">
+        <div className="w-full max-w-2xl bg-white rounded-lg shadow-md p-6">
+          {/* TODO 팀 이름 조회 필요 */}
+          <h2 className="text-3xl font-bold text-gray-800 mb-6">팀 이름 할 일 목록</h2>
+          <form onSubmit={handleAddTask} className="mb-6">
+            <div className="flex items-center">
+              <input
+                  type="text"
+                  id="content"
+                  name="content"
+                  value={content}
+                  onChange={handleContentChange}
+                  required
+                  className="flex-grow mr-2 p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="새로운 할 일을 입력하세요"
+              />
+              <button
+                  type="submit"
+                  className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                추가
+              </button>
+            </div>
+          </form>
+          <TaskList
+              tasks={tasks}
+              onTaskToggle={handleTaskToggle}
+              onTaskDelete={handleTaskDelete}
+              onTaskEdit={handleTaskEdit}
+          />
+        </div>
+      </div>
+  );
+};
+
+export default TeamTaskListPage;

--- a/src/pages/TeamTaskListPage.jsx
+++ b/src/pages/TeamTaskListPage.jsx
@@ -20,21 +20,23 @@ const TeamTaskListPage = () => {
     handleTaskEdit,
     handleTaskToggle,
     fetchTasks
-  } = useTaskList(`/team/${teamId}/tasks`);
+  } = useTaskList(`/teams/${teamId}/tasks`);
 
   useEffect(() => {
     const fetchTeamData = async () => {
       setIsLoading(true);
       try {
-        const teamResponse = await api.get(`/team/${teamId}`);
-        setTeamName(teamResponse.data.name);
-        await fetchTasks();
+        const teamResponse = await api.get(`/teams/${teamId}`);
+        setTeamName(teamResponse.data.teamName);
+        if (teamResponse.status === 200) {
+          await fetchTasks();
+        }
       } catch (err) {
-        console.error(err);
         if (err.response && err.response.status === 403) {
-          setError('이 팀에 접근할 권한이 없습니다.');
+          alert(err.response.data.message);
           navigate('/');
         } else {
+          console.log(err);
           setError('팀 정보를 불러오는 중 오류가 발생했습니다.');
         }
       } finally {
@@ -55,7 +57,7 @@ const TeamTaskListPage = () => {
 
   return (
       <TaskListPage
-          title={`${teamName} 할 일 목록`}
+          title={`${teamName} 팀 할 일 목록`}
           tasks={tasks}
           content={content}
           handleContentChange={handleContentChange}


### PR DESCRIPTION
<!-- [FEAT] 팀 할 일 목록 페이지 구현 및 검색 기능 추가 -->

## 관련 이슈
- Closes #9 

## 변경 사항
1. TeamTaskListPage 컴포넌트 구현
   - 팀별 할 일 목록 조회, 추가, 삭제, 수정, 상태 토글 기능 구현
   - useParams를 사용한 동적 라우팅 파라미터 처리
   - 팀 접근 권한 검증 및 에러 처리 로직 추가
2. 할 일 목록 관리 로직 개선 및 컴포넌트 구조화
   - useTaskList 커스텀 훅 추가
   - TaskListPage 공통 컴포넌트 생성
   - PersonalTaskListPage 및 TeamTaskListPage 리팩토링
3. 검색 기능 추가
   - TaskListPage 컴포넌트 내부에 검색 입력창 추가
5. 기타 수정사항
   - main.jsx 내부 StrictMode 제거

## 스크린샷
백엔드 API 병합 이후의 팀 할 일 화면 예시입니다.
|---|
|![image](https://github.com/user-attachments/assets/7f7edc82-61f6-4792-a01e-856a65e03a41)|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- 팀 할 일 목록 페이지에 대한 접근 권한 검증 로직이 추가되었습니다. 권한이 없는 경우 메인 페이지로 리다이렉트됩니다.
- 현재(10. 14 기준) 백엔드 API가 병합되어 있지 않아, 리다이렉트가 아닌 에러 메시지가 화면에 출력되는것이 정상입니다.
- 할 일 목록 관리 로직이 useTaskList 커스텀 훅으로 추상화되어 코드 재사용성이 향상되었습니다.
- 검색 기능은 UI만 구현되어 있으며, 실제 검색 로직은 아직 구현되지 않았습니다.
