### PR TITLE
[FEAT] 회원가입 페이지 이메일 인증 기능 구현 및 관련 UI 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import PersonalTaskListPage from "./pages/PersonalTaskListPage.jsx";
 import PrivateRoute from "./components/PrivateRoute.jsx";
 import Mypage from "./pages/MyPage.jsx";
 import TeamTaskListPage from "./pages/TeamTaskListPage.jsx";
+import EmailVerifiedPage from './pages/EmailVerifiedPage.jsx';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
           <Routes>
             <Route path="/signup" element={<SignupPage/>}/>
             <Route path="/signin" element={<SigninPage/>}/>
+            <Route path="/email-verified" element={<EmailVerifiedPage/>}/>
             <Route element={<PrivateRoute/>}>
               <Route path="/" element={<PersonalTaskListPage/>}/>
               <Route path="/team/:teamId" element={<TeamTaskListPage/>}/>

--- a/src/pages/EmailVerifiedPage.jsx
+++ b/src/pages/EmailVerifiedPage.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const EmailVerifiedPage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [status, setStatus] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const queryParams = new URLSearchParams(location.search);
+    const statusParam = queryParams.get('status');
+    const messageParam = queryParams.get('message');
+
+    setStatus(statusParam);
+    setMessage(messageParam || '');
+  }, [location]);
+
+  return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="p-8 bg-white shadow-md rounded-md">
+          {status === 'success' ? (
+              <h1 className="text-green-600 font-bold text-xl">이메일 인증이 완료되었습니다!</h1>
+          ) : (
+              <>
+                <h1 className="text-red-600 font-bold text-xl">이메일 인증에 실패했습니다.</h1>
+                {message && <p className="text-gray-600 mt-2">{message}</p>}
+                <button
+                    onClick={() => navigate('/signup')}
+                    className="mt-4 bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700"
+                >
+                  다시 인증하기
+                </button>
+              </>
+          )}
+        </div>
+      </div>
+  );
+};
+
+export default EmailVerifiedPage;

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -11,7 +11,7 @@ const SignupPage = () => {
   });
 
   const [isEmailVerified, setIsEmailVerified] = useState(false);
-  const [emailVerificationSent] = useState(false);
+  const [emailVerificationSent, setEmailVerificationSent] = useState(false);
   const navigate = useNavigate();
 
   const handleChange = (e) => {
@@ -30,6 +30,7 @@ const SignupPage = () => {
       if (response.status === 200) {
         alert('이메일 인증 요청이 발송되었습니다.');
         setIsEmailVerified(true); // 이메일 인증 완료 시 true로 설정
+        setEmailVerificationSent(true);
       }
     } catch (err) {
       console.log(err);
@@ -37,7 +38,6 @@ const SignupPage = () => {
       setIsEmailVerified(false); // 인증 실패 시 false로 설정
     }
   };
-
 
 
   const handleSubmit = async (e) => {
@@ -95,7 +95,7 @@ const SignupPage = () => {
                       className={`w-1/3 bg-blue-600 text-white py-2 px-3 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 ${emailVerificationSent && 'opacity-50 cursor-not-allowed'}`}
                       disabled={emailVerificationSent} // 이메일 발송 후 버튼 비활성화
                   >
-                    {emailVerificationSent ? '인증 요청 발송됨' : '이메일 인증'}
+                    {emailVerificationSent ? '인증 메일 전송' : '이메일 인증'}
                   </button>
                 </div>
               </div>

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -9,6 +9,9 @@ const SignupPage = () => {
     password: '',
     nickname: ''
   });
+
+  const [isEmailVerified, setIsEmailVerified] = useState(false);
+  const [emailVerificationSent] = useState(false);
   const navigate = useNavigate();
 
   const handleChange = (e) => {
@@ -19,8 +22,32 @@ const SignupPage = () => {
     }));
   };
 
+  const handleEmailVerification = async () => {
+    try {
+      const response = await axios.get(
+          `http://localhost:8080/api/auth/verify-email?email=${formData.email}`
+      );
+      if (response.status === 200) {
+        alert('이메일 인증 요청이 발송되었습니다.');
+        setIsEmailVerified(true); // 이메일 인증 완료 시 true로 설정
+      }
+    } catch (err) {
+      console.log(err);
+      alert('이메일 인증 요청에 실패했습니다.');
+      setIsEmailVerified(false); // 인증 실패 시 false로 설정
+    }
+  };
+
+
+
   const handleSubmit = async (e) => {
     e.preventDefault();
+
+    if (!isEmailVerified) {
+      alert('이메일 인증을 완료해주세요.');
+      return;
+    }
+
     try {
       const response = await axios.post(
           'http://localhost:8080/api/auth/signup',
@@ -32,7 +59,7 @@ const SignupPage = () => {
       }
     } catch (err) {
       console.log(err);
-      alert('회원가입에 실패하였습니다.')
+      alert('회원가입에 실패하였습니다.');
     }
   };
 
@@ -51,16 +78,26 @@ const SignupPage = () => {
                 <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
                   이메일
                 </label>
-                <input
-                    type="email"
-                    id="email"
-                    name="email"
-                    value={formData.email}
-                    onChange={handleChange}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    placeholder="user@example.com"
-                    required
-                />
+                <div className="flex items-center">
+                  <input
+                      type="email"
+                      id="email"
+                      name="email"
+                      value={formData.email}
+                      onChange={handleChange}
+                      className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 w-2/3 mr-2"
+                      placeholder="user@example.com"
+                      required
+                  />
+                  <button
+                      type="button"
+                      onClick={handleEmailVerification}
+                      className={`w-1/3 bg-blue-600 text-white py-2 px-3 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 ${emailVerificationSent && 'opacity-50 cursor-not-allowed'}`}
+                      disabled={emailVerificationSent} // 이메일 발송 후 버튼 비활성화
+                  >
+                    {emailVerificationSent ? '인증 요청 발송됨' : '이메일 인증'}
+                  </button>
+                </div>
               </div>
               <div className="mb-3">
                 <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">


### PR DESCRIPTION
<!-- 제목은 아래 주석의 형식을 참고해서 수정해주세요. -->
<!-- [<타입>] <매칭되는 이슈 제목> + <필요한 경우 추가 상세 내용> -->

## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
- Closes #12 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
<!-- ex) 1. 000 엔티티 구현 -->
<!--        - 000 메서드 구현 -->
1. 회원가입 페이지에 이메일 인증 기능 추가
   - 이메일 인증 상태를 관리하기 위한 `isEmailVerified` 상태 추가
   - 이메일 인증 요청을 처리하는 `handleEmailVerification` 함수 추가
   - 회원가입 시 이메일 인증 여부 체크
   - 이메일 인증 버튼 및 UI 업데이트
   - 인증 메일이 발송된 경우 인증 요청 버튼 비활성화

2. 이메일 인증 결과 안내 페이지 생성
   - 이메일 인증 성공 또는 실패 메시지를 표시하는 페이지 구현
   - 인증 상태와 메시지를 URL 쿼리 파라미터에서 받아오는 로직 추가
   - 인증 실패 시 다시 인증할 수 있는 버튼 추가

3. App.jsx에 이메일 인증 결과 안내 페이지 추가
   - `EmailVerifiedPage `컴포넌트 임포트
   - `/email-verified` 경로에 대한 라우트 추가

## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
<!-- 변경사항에 따라 아래 표 템플릿을 활용해주세요 -->
|기능명|스크린샷|
|---|---|
|회원가입 페이지|![회원가입 이메일 인증 버튼 적용 화면](https://github.com/user-attachments/assets/14a23b70-3dab-4462-99e2-ffda30569aa8)|
|인증 요청 시 버튼 비활성화|![인증 이메일 발송 시 버튼 비활성화](https://github.com/user-attachments/assets/1e58604c-c9f0-4e13-a7dd-acaedba27bbd)|
|인증 이메일 수신|![인증 이메일 수신 화면](https://github.com/user-attachments/assets/252c867c-5427-4e6e-bebd-ee6086e17a51)|
|이메일 인증 성공|![이메일 인증 성공](https://github.com/user-attachments/assets/b6951985-8ff9-4700-aa45-37fb4502fb3a)|
|이메일 인증 실패|![이메일 인증 실패](https://github.com/user-attachments/assets/e0bd4338-db86-4372-b158-55e9248a755c)|
|회원가입 완료|![image](https://github.com/user-attachments/assets/a33ece2e-702b-4ac4-b467-1e52f59c27ed)|


## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
<!-- 리뷰어에게 전달할 추가 정보가 있다면 여기에 적어주세요. -->
이메일 인증 기능 구현의 첫 단계입니다. 추후 리팩토링을 통해 UI와 예외처리를 개선할 예정입니다. 

## 추후 업무
<!-- 추후 진행될 과제에 대해 적어주세요. -->
<!-- ex) [ ] 000 기능 구현 -->
- [ ] 마이페이지 팀 초대 수신 목록
- [ ] 팀 초대 수락/거절
- [ ] Topbar 마이페이지 라우터 수정
- [ ] 이메일 인증 관련 리팩토링
